### PR TITLE
Fix Marker __repr__ and __str__ #592

### DIFF
--- a/src/py-opentimelineio/opentimelineio/schema/marker.py
+++ b/src/py-opentimelineio/opentimelineio/schema/marker.py
@@ -4,10 +4,9 @@ from .. import _otio
 
 @add_method(_otio.Marker)
 def __str__(self):
-    return 'Marker("{}", {}, {}, {})'.format(
+    return 'Marker("{}", {}, {})'.format(
         self.name,
-        self.media_reference,
-        self.source_range,
+        self.marked_range,
         self.metadata
     )
 
@@ -17,13 +16,11 @@ def __repr__(self):
     return (
         'otio.schema.Marker('
         'name={}, '
-        'media_reference={}, '
-        'source_range={}, '
+        'marked_range={}, '
         'metadata={}'
         ')'.format(
             repr(self.name),
-            repr(self.media_reference),
-            repr(self.source_range),
+            repr(self.marked_range),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/marker.py
+++ b/src/py-opentimelineio/opentimelineio/schema/marker.py
@@ -4,8 +4,9 @@ from .. import _otio
 
 @add_method(_otio.Marker)
 def __str__(self):
-    return 'Marker("{}", {}, {})'.format(
+    return 'Marker("{}", "{}", {}, {})'.format(
         self.name,
+        self.color,
         self.marked_range,
         self.metadata
     )
@@ -16,10 +17,12 @@ def __repr__(self):
     return (
         'otio.schema.Marker('
         'name={}, '
+        'color={}, '
         'marked_range={}, '
         'metadata={}'
         ')'.format(
             repr(self.name),
+            repr(self.color),
             repr(self.marked_range),
             repr(self.metadata),
         )

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -88,6 +88,40 @@ class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertNotEqual(m, bo)
         self.assertNotEqual(bo, m)
 
+    def test_string(self):
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(5, 24),
+            otio.opentime.RationalTime(10, 24)
+        )
+        m = otio.schema.Marker(
+            name="marker_1",
+            marked_range=tr,
+            color=otio.schema.MarkerColor.GREEN,
+            metadata={'foo': 'bar'}
+        )
+
+        self.assertEqual(
+            repr(m),
+            "otio.schema.Marker("
+            "name='marker_1', "
+            "color=u'GREEN', "
+            "marked_range=otio.opentime.TimeRange("
+            "start_time=otio.opentime.RationalTime(value=5, rate=24), "
+            "duration=otio.opentime.RationalTime(value=10, rate=24)"
+            "), "
+            "metadata={'foo': u'bar'}"
+            ")"
+        )
+        self.assertEqual(
+            str(m),
+            'Marker('
+            '"marker_1", '
+            '"GREEN", '
+            'TimeRange(RationalTime(5, 24), RationalTime(10, 24)), '
+            '{\'foo\': u\'bar\'}'
+            ')'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue: #592

This PR fixes an AttributeError when calling
`repr(otio.schema.Marker())` or `str(otio.schema.Marker())`

Without the fix:
```
>>> repr(otio.schema.Marker())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/devLocal/elabrosse/rdoenv/auto_lineup/otio/lib/python2.7/site-packages/opentimelineio/schema/marker.py", line 25, in __repr__
    repr(self.media_reference),
AttributeError: 'opentimelineio._otio.Marker' object has no attribute 'media_reference'

>>> str(otio.schema.Marker())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/devLocal/elabrosse/rdoenv/auto_lineup/otio/lib/python2.7/site-packages/opentimelineio/schema/marker.py", line 9, in __str__
    self.media_reference,
AttributeError: 'opentimelineio._otio.Marker' object has no attribute 'media_reference'
```

With the fix:
```
>>> repr(otio.schema.Marker())
"otio.schema.Marker(name='', marked_range=otio.opentime.TimeRange(start_time=otio.opentime.RationalTime(value=0, rate=1), duration=otio.opentime.RationalTime(value=0, rate=1)), metadata={})"

>>> str(otio.schema.Marker())
'Marker("", TimeRange(RationalTime(0, 1), RationalTime(0, 1)), {})'
```

The otio.schema.Marker object's `__repr__` and `__str__` methods are referencing a 'media_reference' and a 'source_range' attribute.
however Markers do not have those attributes. They do however have a 'marked_range' attribute that is not referenced in the `__repr__` / `__str__`